### PR TITLE
Fix flaky /chat: use non-streaming LLM call + server-side word streaming

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -4,18 +4,22 @@ Endpoints:
   GET  /health  -> liveness + index status (for deploy health checks)
   POST /chat     -> streams the assistant answer as Server-Sent Events (SSE)
 
-The frontend (Next.js) calls /chat and renders tokens as they arrive. SSE is
-used instead of plain JSON so the answer streams token-by-token, matching the
-chat UX of production assistants.
+The frontend (Next.js) calls /chat and renders tokens as they arrive. We make a
+single non-streaming LLM call and then stream the finished text to the browser
+word-by-word. Upstream token-streaming from the free HF Inference API proved
+unreliable (intermittent httpx.StreamClosed), so this keeps the typing-effect UX
+while removing the flaky dependency — the LLM call is the same one validated at
+30/30 in the eval harness.
 """
 
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
 from sse_starlette.sse import EventSourceResponse
+from starlette.concurrency import run_in_threadpool
 
 from app.config import settings
-from app.rag import answer_stream
+from app.rag import answer_text
 from app.retriever import get_retriever
 
 app = FastAPI(title="Center Desk RAG API", version="1.0.0")
@@ -51,8 +55,15 @@ async def chat(req: ChatRequest):
 
     async def event_generator():
         try:
-            for token in answer_stream(question):
-                yield {"data": token}
+            # answer_text is blocking (network I/O) — run it off the event loop.
+            answer = await run_in_threadpool(answer_text, question)
+            if not answer:
+                answer = "I don't have that procedure in my knowledge base."
+            # Stream word-by-word so the UI still "types" the answer out. Words
+            # carry no whitespace/newlines, so there are no SSE framing issues;
+            # the frontend re-joins them with spaces.
+            for word in answer.split():
+                yield {"data": word}
         except Exception as e:
             yield {"data": f"[error] {e}"}
 


### PR DESCRIPTION
The free HF Inference token-streaming intermittently dropped the connection (httpx.StreamClosed), surfacing as '[error] ... stream has been closed' in the UI — especially from the deployed Space. Switch /chat to a single non-streaming LLM call run in a threadpool, then stream the finished text word-by-word over SSE. Preserves the typing-effect UX, removes the flaky upstream dependency. No frontend change needed.